### PR TITLE
Fix searching through the CP

### DIFF
--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -94,10 +94,7 @@ class Index extends BaseIndex
 
         // if we have no query_by then we query on all string fields
         if (! isset($options['query_by'])) {
-            $options['query_by'] = collect($this->getOrCreateIndex()->retrieve()['fields'] ?? [])
-                ->filter(fn ($field) => $field['type'] == 'string')
-                ->map(fn ($field) => $field['name'])
-                ->join(',');
+            $options['query_by'] = '*';
         }
 
         $searchResults = $this->getOrCreateIndex()->documents->search($options);

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -92,9 +92,15 @@ class Index extends BaseIndex
     {
         $options['q'] = $query;
 
-        // if we have no query_by then we query on all string fields
         if (! isset($options['query_by'])) {
-            $options['query_by'] = '*';
+            $schema = Arr::get($this->config, 'settings.schema', []);
+
+            // if we have fields in our schema use any strings, otherwise *
+            $options['query_by'] = collect($schema['fields'] ?? [])
+                ->filter(fn ($field) => $field['type'] == 'string')
+                ->map(fn ($field) => $field['name'])
+                ->values()
+                ->join(',') ?: '*';
         }
 
         $searchResults = $this->getOrCreateIndex()->documents->search($options);


### PR DESCRIPTION
This PR ensures that when we search we get results!

Typesense requires fields to be passed under `query_by` but Statamic wants to search everything, so we do an initial retrieve on the collection/index to get the schema and then add any string fields to the query_by.