### PR TITLE
Support `sort_by` when querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Any additional settings you want to define per index can be included in the `sta
                 ], 
             ],
         ],
+        /* 
+            Specify a custom sort by order, see the Typesense documentation for more info:
+            https://typesense.org/docs/guide/ranking-and-relevance.html#ranking-based-on-relevance-and-popularity
+        */
+        'sort_by' => '_text_match(buckets: 10):desc,weighted_score:desc',
     ],
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ Any additional settings you want to define per index can be included in the `sta
                 ], 
             ],
         ],
-        /* 
-            Specify a custom sort by order, see the Typesense documentation for more info:
-            https://typesense.org/docs/guide/ranking-and-relevance.html#ranking-based-on-relevance-and-popularity
-        */
-        'sort_by' => '_text_match(buckets: 10):desc,weighted_score:desc',
+        'query' => [
+            /* 
+                Specify a custom sort by order, see the Typesense documentation for more info:
+                https://typesense.org/docs/guide/ranking-and-relevance.html#ranking-based-on-relevance-and-popularity
+            */
+            'sort_by' => '_text_match(buckets: 10):desc,weighted_score:desc',
+        ],
     ],
 ],
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Any additional settings you want to define per index can be included in the `sta
                 ], 
             ],
         ],
-        'query' => [
+        'search_options' => [
             /* 
                 Specify a custom sort by order, see the Typesense documentation for more info:
                 https://typesense.org/docs/guide/ranking-and-relevance.html#ranking-based-on-relevance-and-popularity

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -103,6 +103,12 @@ class Index extends BaseIndex
                 ->join(',') ?: '*';
         }
 
+        if (! isset($options['sort_by'])) {
+            if ($sort = Arr::get($this->config, 'settings.sort_by', false)) {
+                $options['sort_by'] = $sort;
+            }
+        }
+
         $searchResults = $this->getOrCreateIndex()->documents->search($options);
 
         return collect($searchResults['hits'] ?? [])

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -104,7 +104,7 @@ class Index extends BaseIndex
         }
 
         if (! isset($options['sort_by'])) {
-            if ($sort = Arr::get($this->config, 'settings.sort_by', false)) {
+            if ($sort = Arr::get($this->config, 'settings.query.sort_by', false)) {
                 $options['sort_by'] = $sort;
             }
         }

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -104,7 +104,7 @@ class Index extends BaseIndex
         }
 
         if (! isset($options['sort_by'])) {
-            if ($sort = Arr::get($this->config, 'settings.query.sort_by', false)) {
+            if ($sort = Arr::get($this->config, 'settings.search_options.sort_by', false)) {
                 $options['sort_by'] = $sort;
             }
         }


### PR DESCRIPTION
This PR allows a custom `sort_by` to be specified in the index config, which will be used when none is specified.