### PR TITLE
Just pass anything specified in `search_options` over

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ Any additional settings you want to define per index can be included in the `sta
                 ], 
             ],
         ],
+        /* 
+            Pass any of the options from https://typesense.org/docs/26.0/api/search.html#search-parameters
+        */
         'search_options' => [
             /* 
-                Specify a custom sort by order, see the Typesense documentation for more info:
+                eg Specify a custom sort by order, see the Typesense documentation for more info:
                 https://typesense.org/docs/guide/ranking-and-relevance.html#ranking-based-on-relevance-and-popularity
             */
             'sort_by' => '_text_match(buckets: 10):desc,weighted_score:desc',

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -103,6 +103,12 @@ class Index extends BaseIndex
                 ->join(',') ?: '*';
         }
 
+        foreach (Arr::get($this->config, 'settings.search_options', []) as $handle => $value) {
+            if (! isset($options[$handle])) {
+                $options[$handle] = $value;
+            }
+        }
+
         $searchResults = $this->getOrCreateIndex()->documents->search($options);
 
         return collect($searchResults['hits'] ?? [])

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -104,6 +104,10 @@ class Index extends BaseIndex
         }
 
         foreach (Arr::get($this->config, 'settings.search_options', []) as $handle => $value) {
+            if (in_array($handle, ['query_by', 'q'])) {
+                continue;
+            }
+
             if (! isset($options[$handle])) {
                 $options[$handle] = $value;
             }

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -104,10 +104,6 @@ class Index extends BaseIndex
         }
 
         foreach (Arr::get($this->config, 'settings.search_options', []) as $handle => $value) {
-            if (in_array($handle, ['query_by', 'q'])) {
-                continue;
-            }
-
             if (! isset($options[$handle])) {
                 $options[$handle] = $value;
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,6 +44,17 @@ class TestCase extends AddonTestCase
         $app['config']->set('statamic.search.indexes.typesense_index', [
             'driver' => 'typesense',
             'searchables' => ['collection:pages'],
+            'settings' => [
+                'schema' => [
+                    'fields' => [
+                        [
+                            'type' => 'string',
+                            'name' => 'title',
+                            'sort' => true,
+                        ],
+                    ],
+                ],
+            ],
         ]);
     }
 }

--- a/tests/Unit/IndexTest.php
+++ b/tests/Unit/IndexTest.php
@@ -108,4 +108,28 @@ class IndexTest extends TestCase
         $this->assertNotContains('entry::test-1', $export);
         $this->assertContains('entry::test-2', $export);
     }
+
+    #[Test]
+    public function it_sorts_by_specified_order()
+    {
+        $entry1 = Facades\Entry::make()
+            ->id('test-2')
+            ->collection('pages')
+            ->data(['title' => 'Entry 1'])
+            ->save();
+
+        $entry2 = tap(Facades\Entry::make()
+            ->id('test-1')
+            ->collection('pages')
+            ->data(['title' => 'Entry 2']))
+            ->save();
+
+        $results = Facades\Search::index('typesense_index')->searchUsingApi('*', ['sort_by' => 'title:asc']);
+
+        $this->assertSame(['Entry 1', 'Entry 2'], collect($results)->pluck('title')->all());
+
+        $results = Facades\Search::index('typesense_index')->searchUsingApi('*', ['sort_by' => 'title:desc']);
+
+        $this->assertSame(['Entry 2', 'Entry 1'], collect($results)->pluck('title')->all());
+    }
 }


### PR DESCRIPTION
This PR updates the approach in #2 to just allow anything in search_options to be passed over, allowing developers access to the full range of search parameters at: https://typesense.org/docs/26.0/api/search.html#search-parameters