### PR TITLE
Allow typesense to handle pagination

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "guzzlehttp/guzzle": "^7.3",
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/support": "^10.0|^11.0",
-        "statamic/cms": "^5.0",
+        "statamic/cms": "^5.38",
         "typesense/typesense-php": "^4.9"
     },
     "require-dev": {

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -93,7 +93,7 @@ class Index extends BaseIndex
         return $this;
     }
 
-    public function searchUsingApi($query, array $options = []): Collection
+    public function searchUsingApi($query, array $options = []): array
     {
         $options['q'] = $query ?? '';
 
@@ -114,13 +114,16 @@ class Index extends BaseIndex
 
         $searchResults = $this->getOrCreateIndex()->documents->search($options);
 
-        return collect($searchResults['hits'] ?? [])
-            ->map(function ($result, $i) {
-                $result['document']['reference'] = $result['document']['id'];
-                $result['document']['search_score'] = (int) ($result['text_match'] ?? 0);
+        return [
+            'raw' => $searchResults,
+            'results' => collect($searchResults['hits'] ?? [])
+                ->map(function ($result, $i) {
+                    $result['document']['reference'] = $result['document']['id'];
+                    $result['document']['search_score'] = (int) ($result['text_match'] ?? 0);
 
-                return $result['document'];
-            });
+                    return $result['document'];
+                }),
+        ];
     }
 
     public function getOrCreateIndex()

--- a/src/Typesense/Query.php
+++ b/src/Typesense/Query.php
@@ -2,12 +2,56 @@
 
 namespace StatamicRadPack\Typesense\Typesense;
 
+use Illuminate\Pagination\Paginator;
 use Statamic\Search\QueryBuilder;
 
 class Query extends QueryBuilder
 {
+    public $page;
+    public $perPage;
+
+    public $query;
+
     public function getSearchResults($query)
     {
-        return $this->index->searchUsingApi($query);
+        $this->query = $query;
+
+        return $this;
+    }
+
+    private function getApiResults()
+    {
+        return $this->index->searchUsingApi($this->query ?? '', ['per_page' => $this->perPage, 'page' => $this->page]);
+    }
+
+    public function forPage($page, $perPage = null)
+    {
+        $this->page = $page;
+        $this->perPage = $perPage;
+
+        return $this;
+    }
+
+    public function getBaseItems()
+    {
+        $results = $this->getApiResults();
+
+        return $this->transformResults($results['results']);
+    }
+
+    public function paginate($perPage = null, $columns = ['*'], $pageName = 'page', $page = null)
+    {
+        $page = $page ?: Paginator::resolveCurrentPage($pageName);
+
+        $perPage = $perPage ?: $this->defaultPerPageSize();
+
+        $this->forPage($page, $perPage);
+
+        $results = $this->getApiResults();
+
+        return $this->paginator($this->transformResults($results['results']), $results['raw']['found'], $perPage, $page, [
+            'path' => Paginator::resolveCurrentPath(),
+            'pageName' => $pageName,
+        ]);
     }
 }

--- a/tests/Unit/IndexTest.php
+++ b/tests/Unit/IndexTest.php
@@ -126,10 +126,10 @@ class IndexTest extends TestCase
 
         $results = Facades\Search::index('typesense_index')->searchUsingApi('*', ['sort_by' => 'title:asc']);
 
-        $this->assertSame(['Entry 1', 'Entry 2'], collect($results['raw']['hits'])->pluck('title')->all());
+        $this->assertSame(['Entry 1', 'Entry 2'], collect($results['results'])->pluck('title')->all());
 
         $results = Facades\Search::index('typesense_index')->searchUsingApi('*', ['sort_by' => 'title:desc']);
 
-        $this->assertSame(['Entry 2', 'Entry 1'], collect($results['raw']['hits'])->pluck('title')->all());
+        $this->assertSame(['Entry 2', 'Entry 1'], collect($results['results'])->pluck('title')->all());
     }
 }

--- a/tests/Unit/IndexTest.php
+++ b/tests/Unit/IndexTest.php
@@ -126,10 +126,10 @@ class IndexTest extends TestCase
 
         $results = Facades\Search::index('typesense_index')->searchUsingApi('*', ['sort_by' => 'title:asc']);
 
-        $this->assertSame(['Entry 1', 'Entry 2'], collect($results)->pluck('title')->all());
+        $this->assertSame(['Entry 1', 'Entry 2'], collect($results['raw']['hits'])->pluck('title')->all());
 
         $results = Facades\Search::index('typesense_index')->searchUsingApi('*', ['sort_by' => 'title:desc']);
 
-        $this->assertSame(['Entry 2', 'Entry 1'], collect($results)->pluck('title')->all());
+        $this->assertSame(['Entry 2', 'Entry 1'], collect($results['raw']['hits'])->pluck('title')->all());
     }
 }


### PR DESCRIPTION
This PR allows the Typesense server to handle pagination, rather than Statamic paginating on the full result set.

requires https://github.com/statamic/cms/pull/11115