### PR TITLE
Allow filtering to work in the CP

### DIFF
--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -158,6 +158,12 @@ class Index extends BaseIndex
         return $collection;
     }
 
+    public function getTypesenseSchemaFields(): Collection
+    {
+        return collect(Arr::get($this->getOrCreateIndex()->retrieve(), 'fields', []))
+            ->pluck('type', 'name');
+    }
+
     private function getDefaultFields(Searchable $entry): array
     {
         return [

--- a/src/Typesense/Query.php
+++ b/src/Typesense/Query.php
@@ -85,7 +85,7 @@ class Query extends QueryBuilder
 
     private function transformValueForTypeSense(string $schemaType, mixed $value): mixed
     {
-        return match(str_replace('[]', '', $schemaType)) {
+        return match (str_replace('[]', '', $schemaType)) {
             'int32', 'int64' => (int) $value,
             'float' => (float) $value,
             'bool' => (bool) $value,

--- a/src/Typesense/Query.php
+++ b/src/Typesense/Query.php
@@ -62,7 +62,11 @@ class Query extends QueryBuilder
                     break;
 
                 default:
-                    $filterBy .= $where['column'].':'.($where['operator'] != '=' ? $where['operator'] : '').$this->transformValueForTypeSense($schemaType, $where['value']);
+                    if ($where['operator'] == 'like') {
+                        $where['value'] = str_replace(['%"', '"%'], '', $where['value']);
+                    }
+
+                    $filterBy .= $where['column'].':'.(! in_array($where['operator'], ['like']) ? $where['operator'] : '').$this->transformValueForTypeSense($schemaType, $where['value']);
                     break;
             }
 
@@ -73,11 +77,11 @@ class Query extends QueryBuilder
         return $filterBy;
     }
 
-    private function transformArrayOfValuesForTypeSense(string $schemaType, array $values): array
+    private function transformArrayOfValuesForTypeSense(string $schemaType, array $values): string
     {
         return json_encode(
-            collect($where['values'])
-                ->map(fn ($value) => $this->transformValueForTypeSense($schemaType, $values))
+            collect($values)
+                ->map(fn ($value) => ray($value) && $this->transformValueForTypeSense($schemaType, $value))
                 ->values()
                 ->all()
         );

--- a/src/Typesense/Query.php
+++ b/src/Typesense/Query.php
@@ -88,7 +88,7 @@ class Query extends QueryBuilder
         return match (str_replace('[]', '', $schemaType)) {
             'int32', 'int64' => (int) $value,
             'float' => (float) $value,
-            'bool' => (bool) $value,
+            'bool' => $value ? 'true' : 'false',
             default => '`'.$value.'`'
         };
     }

--- a/src/Typesense/Query.php
+++ b/src/Typesense/Query.php
@@ -81,7 +81,7 @@ class Query extends QueryBuilder
     {
         return json_encode(
             collect($values)
-                ->map(fn ($value) => ray($value) && $this->transformValueForTypeSense($schemaType, $value))
+                ->map(fn ($value) => $this->transformValueForTypeSense($schemaType, $value))
                 ->values()
                 ->all()
         );


### PR DESCRIPTION
This PR ensures filtering works in the CP by checking if the filed is in the typesense schema, and if so applying filtering on the typesense side.

Any filters not in the schema will continue to be ignored.