### PR TITLE
Fix query_by in search options being overwritten

### DIFF
--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -100,7 +100,7 @@ class Index extends BaseIndex
 
         $options = array_merge(Arr::get($this->config, 'settings.search_options', []), $options);
 
-        if (! isset($options['query_by'])) {
+        if (! array_key_exists('query_by', $options)) {
             $schema = Arr::get($this->config, 'settings.schema', []);
 
             // if we have fields in our schema use any strings, otherwise *

--- a/src/Typesense/Index.php
+++ b/src/Typesense/Index.php
@@ -98,6 +98,8 @@ class Index extends BaseIndex
     {
         $options['q'] = $query ?? '';
 
+        $options = array_merge(Arr::get($this->config, 'settings.search_options', []), $options);
+
         if (! isset($options['query_by'])) {
             $schema = Arr::get($this->config, 'settings.schema', []);
 
@@ -109,7 +111,7 @@ class Index extends BaseIndex
                 ->join(',') ?: '*';
         }
 
-        $searchResults = $this->getOrCreateIndex()->documents->search(array_merge(Arr::get($this->config, 'settings.search_options', []), $options));
+        $searchResults = $this->getOrCreateIndex()->documents->search($options);
 
         $total = count($searchResults['hits']);
 


### PR DESCRIPTION
This PR fixes a regression where query_by in search_options was being overwritten