### PR TITLE
Allow using multisearch

### DIFF
--- a/config/statamic-typesense.php
+++ b/config/statamic-typesense.php
@@ -2,8 +2,14 @@
 
 return [
 
-    // if you make this higher it will use more memory
-    // but be quicker to update large numbers of documents
+    // If you make this higher it will use more memory
+    // but be quicker to update large numbers of documents.
     'insert_chunk_size' => 100,
+
+    // Use multiSearch via POST for search requests.
+    // Typesense limits GET request parameter size for security
+    // reasons, so if you have many or long search parameters,
+    // you should enable this.
+    'use_multi_search' => env('STATAMIC_TYPESENSE_MULTISEARCH', false)
 
 ];


### PR DESCRIPTION
We're running into problems with larger search queries with Typesense:

```
Error: Request failed with HTTP code 400 | Server said: Query string exceeds max allowed length of 4000. Use the /multi_search end-point for larger payloads.
```

Investigating this quickly led to [this Typesense issue](https://github.com/typesense/typesense/issues/558), which in turn led to this PR. It allows (via config setting) to use multiSearch for search requests, which uses POST instead of GET. [See docs for more details](https://typesense.org/docs/0.22.2/api/documents.html#federated-multi-search).