### PR TITLE
Ensure page and per_page options are set in query

### DIFF
--- a/src/Typesense/Query.php
+++ b/src/Typesense/Query.php
@@ -116,7 +116,12 @@ class Query extends QueryBuilder
 
     private function getApiResults()
     {
-        $options = ['per_page' => $this->perPage, 'page' => $this->page];
+        $options = [];
+
+        if ($this->page && $this->perPage) {
+            $options['page'] = $this->page;
+            $options['per_page'] = $this->perPage;
+        }
 
         if ($filterBy = $this->wheresToFilter($this->wheres)) {
             $options['filter_by'] = $filterBy;


### PR DESCRIPTION
Statamics global search (the one in the top nav) doesn't set the `page` and `per_page` parameters for the search. However, the keys are still set in the `$options` array (as `null`), which leads to a `RequestMalformed` exception.

I guess this must have something to do with the multi_search changes (from https://github.com/statamic-rad-pack/typesense/pull/15), but I haven't had the time to investigate. 

This fix simply ensures to only set the two mentioned keys if they're actually used/set.