### PR TITLE
Push typesense-php version to ^5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "http-interop/http-factory-guzzle": "^1.0",
         "illuminate/support": "^10.0|^11.0|^12.0",
         "statamic/cms": "^5.38",
-        "typesense/typesense-php": "^4.9"
+        "typesense/typesense-php": "^5.1"
     },
     "require-dev": {
         "laravel/pint": "^1.17",


### PR DESCRIPTION
To use this side-by-side with Laravel Scout, I had to update the typesense-php version to the same major version as is used when just using  `composer require typesense/typesense-php` as is recommended in the Laravel Scout docs. 