### PR TITLE
Update Statamic version from 5 to 6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This addon provides a [Typesense](https://typesense.org) search driver for Stata
 
 * PHP 8.2+
 * Laravel 10+
-* Statamic 5
+* Statamic 6
 * Typesense 0.2+
 
 ### Installation


### PR DESCRIPTION
This pull request updates the documentation to reflect support for Statamic 6 instead of Statamic 5.

- Documentation update:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L9-R9): Changed the Statamic version requirement from 5 to 6 to indicate compatibility with the latest version.